### PR TITLE
Add MooX::JSON_LD

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### Added
+
+- Added MooX::JSON_LD helper module
+
 ## [0.0.7]
 
 ### Added

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,7 @@ WriteMakefile(
     PREREQ_PM         => {
         Moose           => 0,
         Moo             => 0,
+        Sub::Quote      => 0, # no longer part of Moo
         Types::Standard => 0,
         JSON            => 0,
     },
@@ -29,4 +30,3 @@ WriteMakefile(
 
     },
 );
-

--- a/lib/MooX/JSON_LD.pm
+++ b/lib/MooX/JSON_LD.pm
@@ -1,0 +1,176 @@
+=head1 NAME
+
+MooX::JSON_LD - Extend Moo to provide JSON-LD mark-up for your objects.
+
+=head1 SYNOPSIS
+
+    # Your Moo (or Moose) Class
+    package::My::Moo::Class
+
+    use Moo;
+
+    use MooX::JSON_LD 'Person';
+
+    has first_name => ( ... json_ld => 1 );
+    has last_name  => ( ... json_ld => 1 );
+
+    has birth date => ( ...
+        json_ld => 'birthDate',
+        json_ld_serializer => sub { shift->birth_date->ymd },
+    );
+
+    # Then, in a program somewhere...
+    use My::Moo::Class;
+
+    my $obj = My::Moo::Class->new({
+      first_name => 'David',
+      last_name  => 'Bowie',
+      birth_date => '1947-01-08',
+    });
+
+    # print a text representation of the JSON-LD
+    print $obj->json_ld;
+
+    # print the raw data structure for the JSON-LD
+    use Data::Dumper;
+    print Dumper $obj->json_ld_data;
+
+=head1 DESCRIPTION
+
+This is a companion module for L<MooX::Role::JSON_LD>. It extends the
+C<has> method to support options to add attributes to the
+C<json_ld_fields> and create the C<json_ld_type> .
+
+To declare the type, add it as the option when importing the module,
+e.g.
+
+  use MooX::JSON_LD 'Thing';
+
+Moo attributes are extended with the following options:
+
+=over
+
+=item C<json_ld>
+
+  has headline => (
+    is      => 'ro',
+    json_ld => 1,
+  );
+
+This adds the "headline" attribute to the C<json_ld_fields>.
+
+  has alt_headline => (
+    is      => 'ro',
+    json_ld => 'alternateHeadline',
+  );
+
+This adds the "alt)headline" attribute to the C<json_ld_fields>, with
+the label "alternateHeadline".
+
+=item C<json_ld_serializer>
+
+  has birth_date => (
+    is      => 'ro',
+    isa     => InstanceOf['DateTime'],
+    json_ld => 'birthDate',
+    json_ld_serializer => sub { shift->birth_date->ymd },
+  );
+
+This allows you to specify a method for converting the data into an
+object that L<JSON> can serialize.
+
+=back
+
+=head1 AUTHOR
+
+Robert Rothenberg <rrwo@cpan.org>
+
+=head1 SEE ALSO
+
+L<MooX::Role::JSON_LD>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2018, Robert Rothenberg.  All Rights Reserved.
+
+This script is free software; you can redistribute it and/or modify it
+under the same terms as Perl itself.
+
+
+=cut
+
+package MooX::JSON_LD;
+
+use strict;
+use warnings;
+
+use Moo       ();
+use Moo::Role ();
+
+use Sub::Quote qw/ quote_sub /;
+
+my %Attributes;
+
+sub import {
+    my ( $class, $type ) = @_;
+
+    my $target = caller;
+
+    no strict 'refs';
+    no warnings 'redefine';
+
+    my $installer =
+      $target->isa("Moo::Object")
+      ? \&Moo::_install_tracked
+      : \&Moo::Role::install_tracked;
+
+    if ( my $has = $target->can('has') ) {
+        my $new_has = sub {
+            $has->( _process_has(@_) );
+        };
+        $installer->( $target, "has", $new_has );
+    }
+
+    if ( defined $type ) {
+        quote_sub "${target}::json_ld_type", "'${type}'";
+    }
+
+    quote_sub "${target}::json_ld_fields",
+      __PACKAGE__ . "::_json_ld_fields('${target}',\@_)";
+
+    Moo::Role->apply_single_role_to_package( $target, 'MooX::Role::JSON_LD' );
+
+}
+
+sub _process_has {
+    my ( $name, %opts ) = @_;
+
+    if ( $opts{json_ld} || $opts{json_ld_serializer} ) {
+
+        my $class = caller(1);
+        $Attributes{$class} //= [];
+
+        my $label  = delete $opts{json_ld};
+        my $method = delete $opts{json_ld_serializer};
+
+        push @{ $Attributes{$class} },
+
+          {
+
+            $label eq "1" ? $name : $label => $method || $name
+
+          }
+
+    }
+
+    ( $name, %opts );
+}
+
+sub _json_ld_fields {
+    my ( $class, $self ) = @_;
+    $Attributes{$class} ;
+}
+
+1;
+
+1;

--- a/lib/MooX/JSON_LD.pm
+++ b/lib/MooX/JSON_LD.pm
@@ -148,7 +148,7 @@ sub _process_has {
     if ( $opts{json_ld} || $opts{json_ld_serializer} ) {
 
         my $class = caller(1);
-        $Attributes{$class} //= [];
+        $Attributes{$class} ||= [];
 
         my $label  = delete $opts{json_ld};
         my $method = delete $opts{json_ld_serializer};

--- a/t/02-moo-moox-json_ld.t
+++ b/t/02-moo-moox-json_ld.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use FindBin '$Bin';
+use lib "$Bin/lib";
+
+use Test::More;
+use MooTester2;
+
+ok(my $obj = MooTester2->new);
+isa_ok($obj, 'MooTester2');
+can_ok($obj, qw[ foo bar boop json_ld_type json_ld_fields
+                 json_ld_data json_ld json_ld_encoder ]);
+
+is($obj->foo, 'Foo', 'foo is Foo');
+is($obj->bar, 'Bar', 'bar is Bar');
+is($obj->boop, 'Bop!', 'boop is Bop!');
+
+is_deeply($obj->json_ld_data, {
+  '@type' => 'Example',
+  '@context' => 'http://schema.org',
+  bax => 'Bar',
+  baz => 'Bar Foo',
+  boop => 'Bop!',
+}, 'JSON data is correct');
+
+is($obj->json_ld, '{
+   "@context" : "http://schema.org",
+   "@type" : "Example",
+   "bax" : "Bar",
+   "baz" : "Bar Foo",
+   "boop" : "Bop!"
+}
+', 'JSON is correct');
+
+done_testing;

--- a/t/lib/MooTester2.pm
+++ b/t/lib/MooTester2.pm
@@ -1,0 +1,28 @@
+package MooTester2;
+
+use Moo;
+
+use MooX::JSON_LD 'Example';
+
+use namespace::autoclean;
+
+has foo => (
+    is      => 'ro',
+    default => 'Foo',
+    json_ld => 'baz',
+    json_ld_serializer => sub { $_[0]->bar . ' ' . $_[0]->foo },
+);
+
+has bar => (
+    is      => 'ro',
+    default => 'Bar',
+    json_ld => 'bax',
+);
+
+has boop => (
+    is      => 'ro',
+    default => 'Bop!',
+    json_ld => 1,
+);
+
+1;


### PR DESCRIPTION
This adds a helper module to use instead of the role:
```perl
    package::My::Moo::Class

    use Moo;

    use MooX::JSON_LD 'Person';

    has first_name => ( ... json_ld => 1 );
    has last_name  => ( ... json_ld => 1 );

    has birth date => ( ...
        json_ld => 'birthDate',
        json_ld_serializer => sub { shift->birth_date->ymd },
    );

```
It creates the needed methods and consumes the role.