### PR TITLE
Type fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### Added
+
+- Allow context to be a hashref or arrayref
+
 ## [0.0.7]
 
 ### Added

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,8 @@
 
 - Allow context to be a hashref or arrayref
 
+- Use JSON::MaybeXS instead of JSON
+
 ## [0.0.7]
 
 ### Added

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ WriteMakefile(
         Moose           => 0,
         Moo             => 0,
         Types::Standard => 0,
-        JSON            => 0,
+        JSON::MaybeXS   => 0,
     },
     BUILD_REQUIRES    => {
         Test::More    => 0,
@@ -29,4 +29,3 @@ WriteMakefile(
 
     },
 );
-

--- a/lib/MooX/Role/JSON_LD.pm
+++ b/lib/MooX/Role/JSON_LD.pm
@@ -146,7 +146,7 @@ use 5.6.0;
 use Moo::Role;
 use JSON;
 use Carp;
-use Types::Standard qw[InstanceOf Str];
+use Types::Standard qw[ArrayRef HashRef InstanceOf Str];
 
 our $VERSION = '0.0.7';
 
@@ -164,7 +164,7 @@ sub _build_json_ld_encoder {
 }
 
 has context => (
-  isa => Str,
+  isa => Str | HashRef | ArrayRef,
   is  => 'ro',
   builder => '_build_context',
 );

--- a/lib/MooX/Role/JSON_LD.pm
+++ b/lib/MooX/Role/JSON_LD.pm
@@ -144,8 +144,8 @@ package MooX::Role::JSON_LD;
 use 5.6.0;
 
 use Moo::Role;
-use JSON;
 use Carp;
+use JSON::MaybeXS;
 use Types::Standard qw[ArrayRef HashRef InstanceOf Str];
 
 our $VERSION = '0.0.7';
@@ -153,7 +153,7 @@ our $VERSION = '0.0.7';
 requires qw[json_ld_type json_ld_fields];
 
 has json_ld_encoder => (
-  isa => InstanceOf['JSON'],
+  isa => InstanceOf[ qw/ Cpanel::JSON::XS JSON JSON::PP JSON::XS /],
   is  => 'ro',
   lazy => 1,
   builder => '_build_json_ld_encoder',


### PR DESCRIPTION
- Allow context to be hashref or arrayref
- Use JSON::MaybeXS and allow different JSON encoders.