### PR TITLE
Ignore nulls and run json_ld_data methods

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ WriteMakefile(
         Sub::Quote      => 0, # no longer part of Moo
         Types::Standard => 0,
         JSON::MaybeXS   => 0,
+        Ref::Util       => 0,
     },
     BUILD_REQUIRES    => {
         Test::More    => 0,

--- a/lib/MooX/Role/JSON_LD.pm
+++ b/lib/MooX/Role/JSON_LD.pm
@@ -146,6 +146,7 @@ use 5.6.0;
 use Moo::Role;
 use Carp;
 use JSON::MaybeXS;
+use Ref::Util qw/ is_plain_coderef is_plain_hashref is_ref is_blessed_ref /;
 use Types::Standard qw[ArrayRef HashRef InstanceOf Str];
 
 our $VERSION = '0.0.11';
@@ -173,6 +174,13 @@ sub _build_context {
   return 'http://schema.org/';
 }
 
+sub _resolve_nested {
+    my ($val) = @_;
+    is_blessed_ref($val) && $val->can('json_ld_data')
+        ? $val->json_ld_data
+        : $val;
+}
+
 sub json_ld_data {
   my $self = shift;
 
@@ -182,22 +190,36 @@ sub json_ld_data {
   };
 
   foreach (@{$self->json_ld_fields}) {
-    if (my $reftype = ref $_) {
-      if ($reftype eq 'HASH') {
-        while (my ($key, $val) = each %{$_}) {
-          if (ref $val eq 'CODE') {
-            $data->{$key} = $val->($self);
-          } else {
-            $data->{$key} = $self->$val;
+
+      if (is_ref($_)) {
+
+          if (is_plain_hashref($_)) {
+
+              while (my ($key, $val) = each %{$_}) {
+
+                  if (defined (my $res = is_plain_coderef($val)
+                               ? $val->($self)
+                               : $self->$val)) {
+                      $data->{$key} = _resolve_nested($res);
+                  }
+
+              }
+
           }
-        }
-      } else {
-        carp "Weird JSON-LD reference: $reftype";
-        next;
+          else {
+              carp "Weird JSON-LD reference: " . ref $_;
+              next;
+          }
+
       }
-    } else {
-      $data->{$_} = $self->$_;
-    }
+      else {
+
+          if (defined (my $res = $self->$_)) {
+              $data->{$_} = _resolve_nested($res);
+          }
+
+      }
+
   }
 
   return $data;

--- a/t/05-moo-nested.t
+++ b/t/05-moo-nested.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+
+use FindBin '$Bin';
+use lib "$Bin/lib";
+
+use Test::More;
+use MooTester2;
+use MooTester3;
+
+ok(my $obj = MooTester3->new( zip => MooTester2->new(), boop => undef ));
+isa_ok($obj, 'MooTester3' );
+can_ok($obj, qw[ foo bar boop json_ld_type json_ld_fields
+                 json_ld_data json_ld json_ld_encoder ]);
+
+is($obj->foo, 'Foo', 'foo is Foo');
+is($obj->bar, 'Bar', 'bar is Bar');
+is($obj->boop, undef, 'boop is undefined');
+
+is_deeply($obj->json_ld_data, {
+  '@type' => 'Another',
+  '@context' => 'http://schema.org/',
+  bax => 'Bar',
+  baz => 'Bar Foo',
+  zip => {
+      '@type' => 'Example',
+      '@context' => 'http://schema.org/',
+      bax => 'Bar',
+      baz => 'Bar Foo',
+      boop => 'Bop!',
+  },
+}, 'JSON data is correct');
+
+is($obj->json_ld, '{
+   "@context" : "http://schema.org/",
+   "@type" : "Another",
+   "bax" : "Bar",
+   "baz" : "Bar Foo",
+   "zip" : {
+      "@context" : "http://schema.org/",
+      "@type" : "Example",
+      "bax" : "Bar",
+      "baz" : "Bar Foo",
+      "boop" : "Bop!"
+   }
+}
+', 'JSON is correct');
+
+done_testing;


### PR DESCRIPTION
Use Ref::Util for resolving reference types. This will provide a
significant performance improvement.

Only set values if they are defined.

If a value is an object with a json_ld_data method, then run that
method.