### PR TITLE
Fix inheritance issues

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,8 @@
 
 ### Tests
 
+- Allow `_build_json_ld_encoder` method to be overridden.
+
 - Explicitly test subclass parent.
 
 ## [0.0.14] - 2018-07-31

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### Tests
+
+- Explicitly test subclass parent.
+
 ## [0.0.14] - 2018-07-31
 
 ### Changed

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,12 @@
 
 ### Tests
 
+- Do not apply role from MooX::JSON_LD if the target is a role or it
+  already has the expected methods.
+
+  This should fix issues with inheritance, but existing code that
+  works around this bug may need to be updated.
+
 - Allow `_build_json_ld_encoder` method to be overridden.
 
 - Explicitly test subclass parent.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,7 +29,7 @@ WriteMakefile(
             },
         },
         x_contributors => [
-            'Robert Rothenberg <rrwo@cpan.com>',
+            'Robert Rothenberg <rrwo@cpan.org>',
             'Mohammad S Anwar <mohammad.anwar@yahoo.com>',
         ],
     },

--- a/lib/MooX/JSON_LD.pm
+++ b/lib/MooX/JSON_LD.pm
@@ -108,6 +108,7 @@ use Moo       ();
 use Moo::Role ();
 
 use MRO::Compat;
+use List::Util qw/ all /;
 use Sub::Quote qw/ quote_sub /;
 
 our $VERSION = '0.0.15';
@@ -156,7 +157,14 @@ sub import {
         };
 
 
-    Moo::Role->apply_single_role_to_package( $target, 'MooX::Role::JSON_LD' );
+    unless ( all { $target->can($_) }
+        qw/ json_ld_encoder json_ld_data json_ld / )
+    {
+
+        Moo::Role->apply_single_role_to_package( $target,
+            'MooX::Role::JSON_LD' );
+
+    }
 
 }
 

--- a/lib/MooX/JSON_LD.pm
+++ b/lib/MooX/JSON_LD.pm
@@ -107,6 +107,7 @@ use warnings;
 use Moo       ();
 use Moo::Role ();
 
+use MRO::Compat;
 use Sub::Quote qw/ quote_sub /;
 
 our $VERSION = '0.0.15';
@@ -143,9 +144,9 @@ sub import {
         {
             '$code' => \sub {
                 my ($self) = @_;
-                my $fields = eval { $self->next::method };
+                my $fields = $self->maybe::next::method || [];
                 return [
-                    @{$fields || []},
+                    @{$fields},
                     @{$Attributes{$target} || []}
                 ];
             },

--- a/lib/MooX/Role/JSON_LD.pm
+++ b/lib/MooX/Role/JSON_LD.pm
@@ -144,8 +144,10 @@ package MooX::Role::JSON_LD;
 use 5.6.0;
 
 use Moo::Role;
+
 use Carp;
 use JSON::MaybeXS;
+use MRO::Compat;
 use Types::Standard qw[ArrayRef HashRef InstanceOf Str is_CodeRef is_HashRef is_Ref is_Object];
 
 our $VERSION = '0.0.15';
@@ -154,14 +156,15 @@ requires qw[json_ld_type json_ld_fields];
 
 has json_ld_encoder => (
   isa => InstanceOf[ qw/ Cpanel::JSON::XS JSON JSON::PP JSON::XS /],
-  is  => 'ro',
-  lazy => 1,
+  is  => 'lazy',
   builder => '_build_json_ld_encoder',
 );
 
 sub _build_json_ld_encoder {
-  return JSON->new->canonical->utf8->space_after->indent->pretty;
-}
+    my ($self) = @_;
+    return $self->maybe::next::method ||
+        JSON->new->canonical->utf8->space_after->indent->pretty;
+};
 
 has context => (
   isa => Str | HashRef | ArrayRef,

--- a/t/02-moo-moox-json_ld.t
+++ b/t/02-moo-moox-json_ld.t
@@ -24,13 +24,6 @@ is_deeply($obj->json_ld_data, {
   boop => 'Bop!',
 }, 'JSON data is correct');
 
-is($obj->json_ld, '{
-   "@context" : "http://schema.org/",
-   "@type" : "Example",
-   "bax" : "Bar",
-   "baz" : "Bar Foo",
-   "boop" : "Bop!"
-}
-', 'JSON is correct');
+is($obj->json_ld, '{"@context":"http://schema.org/","@type":"Example","bax":"Bar","baz":"Bar Foo","boop":"Bop!"}', 'JSON is correct');
 
 done_testing;

--- a/t/04-moox-json-subclass.t
+++ b/t/04-moox-json-subclass.t
@@ -9,6 +9,7 @@ use MooTester3;
 
 ok(my $obj = MooTester3->new);
 isa_ok($obj, 'MooTester3' );
+isa_ok($obj, 'MooTester2' );
 can_ok($obj, qw[ foo bar boop json_ld_type json_ld_fields
                  json_ld_data json_ld json_ld_encoder ]);
 

--- a/t/lib/MooTester2.pm
+++ b/t/lib/MooTester2.pm
@@ -3,6 +3,7 @@ package MooTester2;
 use Moo;
 
 use MooX::JSON_LD 'Example';
+use JSON::MaybeXS;
 
 use namespace::autoclean;
 
@@ -24,5 +25,10 @@ has boop => (
     default => 'Bop!',
     json_ld => 1,
 );
+
+around _build_json_ld_encoder => sub {
+    return JSON->new->utf8->canonical;
+};
+
 
 1;


### PR DESCRIPTION
If you have a class that uses MooX::JSON_LD, and another class inherits from that but also uses MooX::JSON_LD, then the role is applied twice, which can break things for the existing classes, especially if you want to override the json_ld_encoder.

This fixes that by checking if all of the expected methods in the role exist. If they do, then it will not apply the role.
